### PR TITLE
When using OAuth2 instead of shared secret auth, don't show a client_…

### DIFF
--- a/rev-manifest.json
+++ b/rev-manifest.json
@@ -1,8 +1,8 @@
 {
   "lib.css": "lib-d803823ef5.css",
-  "lib.js": "lib-5f6d2726ba.js",
-  "min.css": "min-beed179dad.css",
-  "min.css.map": "min-39d0404066.css.map",
-  "swagger-ui.min.js": "swagger-ui-1a6c86888e.min.js",
-  "swagger-ui.min.js.map": "swagger-ui-e0fabf1352.min.js.map"
+  "lib.js": "lib-da89c9e44f.js",
+  "min.css": "min-455b26342c.css",
+  "min.css.map": "min-5f91d22f62.css.map",
+  "swagger-ui.min.js": "swagger-ui-da1d10363f.min.js",
+  "swagger-ui.min.js.map": "swagger-ui-86af3ec59e.min.js.map"
 }

--- a/src/main/javascript/view/MainView.js
+++ b/src/main/javascript/view/MainView.js
@@ -101,6 +101,7 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
     this.model.baseUrl = window.baseUrl;
     this.model.accessToken = window.accessToken;
     this.model.clientIdOrInfoDescriptionDoExist = window.clientId || (this.model.info && this.model.info.description);
+    this.model.audience = window.audience;
     if (this.model.securityDefinitions) {
       for (var name in this.model.securityDefinitions) {
         var auth = this.model.securityDefinitions[name];

--- a/src/main/template/main.handlebars
+++ b/src/main/template/main.handlebars
@@ -146,7 +146,7 @@
                                       <p>Cimpress Open uses Auth0 as an authentication service. Every Cimpress Open Portal user has an Auth0 account. The email address you registered with is the username of your Auth0 account. For more information, see the <a href="https://developer.cimpress.io/docs/developers/auth0.html" target="_blank">authentication documentation</a>.</p>
                                       <h5 id="useful-information-about-this-api">Useful Information About This API</h5>
                                       <p>
-                                          <strong>Client ID:</strong> {{clientId}}<br/>
+                                          {{#unless audience}}<strong>Client ID:</strong> {{clientId}}<br/>{{/unless}}
                                           {{#if baseUrl}}<strong>Base URL:</strong> {{baseUrl}}{{/if}}
                                       </p>
                                       {{#if accessToken}}


### PR DESCRIPTION
…id in the useful information section